### PR TITLE
add nodejs based healthcheck for docker health management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jobs:
           script: npm test
           language: node_js
           node_js:
-              - '8'
+              - '10'
         - stage: build docker image
           services:
               - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN npm install --production
 
 COPY . /src
 
+HEALTHCHECK --interval=10s --timeout=10s --start-period=5s --retries=3 CMD node healthcheck.js || exit 1
+
 RUN addgroup -S nmap_group && adduser -S -g nmap_group nmap_user 
 
 USER nmap_user

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN npm install --production
 
 COPY . /src
 
-HEALTHCHECK --interval=5s --timeout=5s --start-period=30s --retries=3 CMD node healthcheck.js || exit 1
+HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 CMD node healthcheck.js || exit 1
 
 RUN addgroup -S nmap_group && adduser -S -g nmap_group nmap_user 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN npm install --production
 
 COPY . /src
 
-HEALTHCHECK --interval=10s --timeout=10s --start-period=5s --retries=3 CMD node healthcheck.js || exit 1
+HEALTHCHECK --interval=5s --timeout=5s --start-period=30s --retries=3 CMD node healthcheck.js || exit 1
 
 RUN addgroup -S nmap_group && adduser -S -g nmap_group nmap_user 
 

--- a/healthcheck.js
+++ b/healthcheck.js
@@ -1,0 +1,24 @@
+const http = require ('http');
+
+const request = http.request ('http://localhost:8080/status', response => {
+
+	// exit with error for any non 2xx status code
+	process.exit (response.statusCode >= 300 ? 1 : 0);
+
+	/*
+	const dataChunks = [];
+
+	response.on ('data', chunk => {
+		dataChunks.push (chunk);
+	});
+
+	response.on ('close', () => {
+		const txtResponse = Buffer.concat (dataChunks).toString ('utf8');
+		const jsonResponse = JSON.parse (txtResponse);
+		if (jsonResponse.healthcheck === 'DOWN') process.exit (1);
+	});
+	*/
+
+});
+
+request.end ();

--- a/healthcheck.js
+++ b/healthcheck.js
@@ -1,24 +1,12 @@
-const http = require ('http');
+try {
 
-const request = http.request ('http://localhost:8080/status', response => {
+	require('http').request('http://localhost:8080/status', response => {
 
-	// exit with error for any non 2xx status code
-	process.exit (response.statusCode >= 300 ? 1 : 0);
+		// exit with error for any non 2xx status code
+		process.exit(response.statusCode >= 300 ? 1 : 0);
 
-	/*
-	const dataChunks = [];
+	}).end();
 
-	response.on ('data', chunk => {
-		dataChunks.push (chunk);
-	});
-
-	response.on ('close', () => {
-		const txtResponse = Buffer.concat (dataChunks).toString ('utf8');
-		const jsonResponse = JSON.parse (txtResponse);
-		if (jsonResponse.healthcheck === 'DOWN') process.exit (1);
-	});
-	*/
-
-});
-
-request.end ();
+} catch (err) {
+	process.exit(1);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,9 +33,9 @@
             }
         },
         "@securecodebox/scanner-scaffolding": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@securecodebox/scanner-scaffolding/-/scanner-scaffolding-2.1.3.tgz",
-            "integrity": "sha512-yUEQUtCPsu4ZSeemPDfYc8KLoZUvrvrMNk8zZoNyfCoA7pLaWHvKc5Cy479Q3JQDUt2WNPUYievwGWVfVCTkxg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@securecodebox/scanner-scaffolding/-/scanner-scaffolding-2.2.0.tgz",
+            "integrity": "sha512-+Y1rIgrDRunXoWcP5XPcORTzNMqNOPaV4H9A0fjxFmeI0bY9GkfmVWyB5Tw029iII6mR6nziWJpETlynTGU50w==",
             "requires": {
                 "axios": "^0.18.0",
                 "express": "^4.16.3",
@@ -84,7 +84,7 @@
         },
         "acorn-jsx": {
             "version": "3.0.1",
-            "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
             "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
             "dev": true,
             "requires": {
@@ -93,7 +93,7 @@
             "dependencies": {
                 "acorn": {
                     "version": "3.3.0",
-                    "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
                     "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
                     "dev": true
                 }
@@ -477,7 +477,7 @@
         },
         "array-equal": {
             "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
             "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
             "dev": true
         },
@@ -601,7 +601,7 @@
             "dependencies": {
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
@@ -614,7 +614,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
@@ -708,7 +708,7 @@
         },
         "babel-plugin-istanbul": {
             "version": "4.1.6",
-            "resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
             "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
             "dev": true,
             "requires": {
@@ -726,7 +726,7 @@
         },
         "babel-plugin-syntax-object-rest-spread": {
             "version": "6.13.0",
-            "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
             "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
             "dev": true
         },
@@ -1609,7 +1609,7 @@
         },
         "eslint": {
             "version": "4.19.1",
-            "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
             "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
             "dev": true,
             "requires": {
@@ -1681,7 +1681,7 @@
         },
         "espree": {
             "version": "3.5.4",
-            "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
             "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
             "dev": true,
             "requires": {
@@ -1879,7 +1879,7 @@
         },
         "external-editor": {
             "version": "2.2.0",
-            "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
             "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
             "dev": true,
             "requires": {
@@ -2643,7 +2643,7 @@
         },
         "get-stream": {
             "version": "3.0.0",
-            "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
             "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
             "dev": true
         },
@@ -3042,7 +3042,7 @@
         },
         "is-builtin-module": {
             "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
@@ -3536,7 +3536,7 @@
         },
         "jest-get-type": {
             "version": "22.4.3",
-            "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
             "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
             "dev": true
         },
@@ -3912,7 +3912,7 @@
         },
         "json5": {
             "version": "0.5.1",
-            "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
             "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
             "dev": true
         },
@@ -3976,7 +3976,7 @@
         },
         "load-json-file": {
             "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
@@ -4160,7 +4160,7 @@
         },
         "minimist": {
             "version": "0.0.8",
-            "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
             "dev": true
         },
@@ -4187,7 +4187,7 @@
         },
         "mkdirp": {
             "version": "0.5.1",
-            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "dev": true,
             "requires": {
@@ -4485,7 +4485,7 @@
         },
         "os-homedir": {
             "version": "1.0.2",
-            "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
             "dev": true
         },
@@ -4502,7 +4502,7 @@
         },
         "os-tmpdir": {
             "version": "1.0.2",
-            "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
@@ -4588,7 +4588,7 @@
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
@@ -4932,7 +4932,7 @@
         },
         "regexpp": {
             "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
             "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
             "dev": true
         },
@@ -5025,7 +5025,7 @@
         },
         "require-uncached": {
             "version": "1.0.3",
-            "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "dev": true,
             "requires": {
@@ -5130,7 +5130,7 @@
         },
         "safe-regex": {
             "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
@@ -5444,7 +5444,7 @@
                 },
                 "minimist": {
                     "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                     "dev": true
                 }
@@ -5894,7 +5894,7 @@
         },
         "strip-eof": {
             "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
             "dev": true
         },
@@ -5957,7 +5957,7 @@
         },
         "through": {
             "version": "2.3.8",
-            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
         },
@@ -6305,7 +6305,7 @@
             "dependencies": {
                 "minimist": {
                     "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                     "dev": true
                 }
@@ -6377,7 +6377,7 @@
         },
         "wrap-ansi": {
             "version": "2.1.0",
-            "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
@@ -6407,7 +6407,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
@@ -6485,7 +6485,7 @@
         },
         "yargs": {
             "version": "11.1.0",
-            "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
             "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
             "dev": true,
             "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,9 +100,9 @@
             }
         },
         "acorn-walk": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.0.tgz",
-            "integrity": "sha512-ugTb7Lq7u4GfWSqqpwE0bGyoBZNMTok/zDBXxfEG0QM50jNlGhIWjRC1pPN7bvV1anhF+bs+/gNcRw+o55Evbg==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+            "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
             "dev": true
         },
         "ajv": {
@@ -125,7 +125,7 @@
         },
         "ansi-escapes": {
             "version": "3.1.0",
-            "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
             "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
             "dev": true
         },
@@ -581,7 +581,7 @@
         },
         "axios": {
             "version": "0.18.0",
-            "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
             "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
             "requires": {
                 "follow-redirects": "^1.3.0",
@@ -1905,7 +1905,7 @@
         },
         "fast-deep-equal": {
             "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
             "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
             "dev": true
         },
@@ -1986,7 +1986,7 @@
         },
         "finalhandler": {
             "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
             "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
             "requires": {
                 "debug": "2.6.9",
@@ -2696,9 +2696,9 @@
             }
         },
         "globals": {
-            "version": "11.8.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-            "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+            "version": "11.9.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
+            "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
             "dev": true
         },
         "globby": {
@@ -2716,7 +2716,7 @@
             "dependencies": {
                 "pify": {
                     "version": "2.3.0",
-                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
                 }
@@ -2761,9 +2761,9 @@
             "dev": true
         },
         "har-validator": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.2.tgz",
-            "integrity": "sha512-OFxb5MZXCUMx43X7O8LK4FKggEQx6yC5QPmOcBnYbJ9UjxEcMcrMbaR0af5HZpqeFopw2GwQRQi34ZXI7YLM5w==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "dev": true,
             "requires": {
                 "ajv": "^6.5.5",
@@ -2913,7 +2913,7 @@
         },
         "http-errors": {
             "version": "1.6.3",
-            "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
             "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
             "requires": {
                 "depd": "~1.1.2",
@@ -3989,7 +3989,7 @@
             "dependencies": {
                 "pify": {
                     "version": "2.3.0",
-                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
                 }
@@ -4067,7 +4067,7 @@
         },
         "media-typer": {
             "version": "0.3.0",
-            "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
         },
         "mem": {
@@ -4628,7 +4628,7 @@
             "dependencies": {
                 "pify": {
                     "version": "2.3.0",
-                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
                 }
@@ -4701,9 +4701,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.1.tgz",
-            "integrity": "sha512-4rgV2hyc/5Pk0XHH4VjJWHRgVjgRbpMfLQjREAhHBtyW1UvTFkjJEsueGYNYYZd9mn97K+1qv0EBwm11zoaSgA==",
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.2.tgz",
+            "integrity": "sha512-YgPLFFA0CdKL4Eg2IHtUSjzj/BWgszDHiNQAe0VAIBse34148whfdzLagRL+QiKS+YfK5ftB6X4v/MBw8yCoug==",
             "dev": true
         },
         "pretty-format": {
@@ -4883,7 +4883,7 @@
         },
         "readable-stream": {
             "version": "2.3.6",
-            "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
@@ -6468,7 +6468,7 @@
         },
         "xmlbuilder": {
             "version": "9.0.7",
-            "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
             "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
         },
         "y18n": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "url": "git@github.com:secureCodeBox/scanner-infrastructure-nmap.git"
     },
     "dependencies": {
-        "@securecodebox/scanner-scaffolding": "^2.1.3",
+        "@securecodebox/scanner-scaffolding": "^2.2.0",
         "lodash": "^4.17.10",
         "node-nmap": "^4.0.0",
         "uuid": "^3.2.1"


### PR DESCRIPTION
added nodejs based health check for docker container health management. Healthcheck.js contains commented hints on how to extend status page parsing. The current implementation is based solely on the http status code.