### PR TITLE
fixed type error for unresolvable host detection

### DIFF
--- a/src/nmap.js
+++ b/src/nmap.js
@@ -153,7 +153,7 @@ async function worker(targets) {
 
             results.push({ findings: result, raw });
         } catch (err) {
-            var stringErr = err.message ? err.message : (err.toString ? err.toString() : (''+err));
+            var stringErr = extractErrorMessage(err);
             if (stringErr.startsWith(`Failed to resolve "${location}".`) || stringErr === '\n') {
                 console.warn(err);
                 results.push({
@@ -181,6 +181,12 @@ async function worker(targets) {
     }
 
     return joinResults(results);
+}
+
+function extractErrorMessage(err) {
+    if (err.message) return err.message;
+    if (err.toString) return err.toString();
+    return '' + err;
 }
 
 module.exports.transform = transform;

--- a/src/nmap.js
+++ b/src/nmap.js
@@ -153,7 +153,8 @@ async function worker(targets) {
 
             results.push({ findings: result, raw });
         } catch (err) {
-            if (err.startsWith(`Failed to resolve "${location}".`) || err === '\n') {
+            var stringErr = err.message ? err.message : (err.toString ? err.toString() : (''+err));
+            if (stringErr.startsWith(`Failed to resolve "${location}".`) || stringErr === '\n') {
                 console.warn(err);
                 results.push({
                     findings: [


### PR DESCRIPTION
Tried to interpret an "Error" as "string"; type error fixed by extracting the error message in a fail-safe way. The code should no longer crash during exception handling for unresolvable hosts!

Steps to reproduce:
- start secureCodeBox
- start NMAP process
- select a non-resolvable host as target (i.e. a domain that does not exist)
- start scan