### PR TITLE
Don't execute multiple scans in parallel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "securebox-nmap",
-    "version": "0.0.1",
+    "version": "1.0.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -411,9 +411,9 @@
             }
         },
         "@securecodebox/scanner-scaffolding": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/@securecodebox/scanner-scaffolding/-/scanner-scaffolding-2.2.4.tgz",
-            "integrity": "sha512-1FZcKLxXkpaw8vgwWu8pDk8ZNzOYMJpHIPANMNFUzGLmg7YpcNFqjQCyv1rdZOGdUrEdtdERGgEuxsxe7sukWg==",
+            "version": "2.2.5-0",
+            "resolved": "https://registry.npmjs.org/@securecodebox/scanner-scaffolding/-/scanner-scaffolding-2.2.5-0.tgz",
+            "integrity": "sha512-9rJS00K0Yr8TQ4DMGsgMGYCVKVoaNFRyF4sGvNF2Jr9xllqxL4dM4xXRjAa2U1XPBUydyF7bQHKoKrLycHdN/g==",
             "requires": {
                 "axios": "^0.18.1",
                 "express": "^4.16.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "securebox-nmap",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -411,9 +411,9 @@
             }
         },
         "@securecodebox/scanner-scaffolding": {
-            "version": "2.2.5-0",
-            "resolved": "https://registry.npmjs.org/@securecodebox/scanner-scaffolding/-/scanner-scaffolding-2.2.5-0.tgz",
-            "integrity": "sha512-9rJS00K0Yr8TQ4DMGsgMGYCVKVoaNFRyF4sGvNF2Jr9xllqxL4dM4xXRjAa2U1XPBUydyF7bQHKoKrLycHdN/g==",
+            "version": "2.2.5",
+            "resolved": "https://registry.npmjs.org/@securecodebox/scanner-scaffolding/-/scanner-scaffolding-2.2.5.tgz",
+            "integrity": "sha512-ExR+I+DmT6hmgkZl3LdiD9J2M+1LVAH4gOUUM+KCc8H4h0vJyoj5O7ScFt5eOz+Pdaa5g84mU8OXmPwlASjo1A==",
             "requires": {
                 "axios": "^0.18.1",
                 "express": "^4.16.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "url": "git@github.com:secureCodeBox/scanner-infrastructure-nmap.git"
     },
     "dependencies": {
-        "@securecodebox/scanner-scaffolding": "^2.2.4",
+        "@securecodebox/scanner-scaffolding": "^2.2.5",
         "lodash": "^4.17.11",
         "node-nmap": "^4.0.0",
         "uuid": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "securebox-nmap",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "SecureCodeBox Nmap Scanner",
     "author": "iteratec GmbH",
     "license": "Apache-2.0",


### PR DESCRIPTION
Updating the `nodejs-scanner-scaffolding` lib to a new version with a fix in the polling logic.