### PR TITLE
Recover from rttvar errors

### DIFF
--- a/lib/node-nmap.js
+++ b/lib/node-nmap.js
@@ -188,11 +188,9 @@ class NmapScan extends EventEmitter {
         });
 
         this.child.on('error', err => {
-            console.log('Nmap encountered an error.');
-            console.log(err);
-            console.log(`Error message "${err.message}"`);
+            console.log(`Error in Nmap Scan: "${err.message}"`);
             if (err.message.startsWith('RTTVAR has grown to over')) {
-                console.log('RTTVAR Error, should hopefully be recoverable.');
+                console.log('RTTVAR Error: only a Round Trip Time change. Moving on.');
                 return;
             }
 

--- a/lib/node-nmap.js
+++ b/lib/node-nmap.js
@@ -188,6 +188,12 @@ class NmapScan extends EventEmitter {
         });
 
         this.child.on('error', err => {
+            console.log(err);
+            if (err.message.startsWith('RTTVAR has grown to over')) {
+                console.log('RTTVAR Error, should hopefully be recoverable.');
+                return;
+            }
+
             this.killChild();
             if (err.code === 'ENOENT') {
                 this.emit('error', 'NMAP not found at command location: ' + nmap.nmapLocation);

--- a/lib/node-nmap.js
+++ b/lib/node-nmap.js
@@ -190,6 +190,7 @@ class NmapScan extends EventEmitter {
         this.child.on('error', err => {
             console.log('Nmap encountered an error.');
             console.log(err);
+            console.log(`Error message "${err.message}"`);
             if (err.message.startsWith('RTTVAR has grown to over')) {
                 console.log('RTTVAR Error, should hopefully be recoverable.');
                 return;

--- a/lib/node-nmap.js
+++ b/lib/node-nmap.js
@@ -188,6 +188,7 @@ class NmapScan extends EventEmitter {
         });
 
         this.child.on('error', err => {
+            console.log('Nmap encountered an error.');
             console.log(err);
             if (err.message.startsWith('RTTVAR has grown to over')) {
                 console.log('RTTVAR Error, should hopefully be recoverable.');


### PR DESCRIPTION
Nmap scans sometimes randomly crash with its log output looking something like this:

```txt
SCANNING location: "1.2.3.4/24", parameters: "--top-ports 50"
RTTVAR has grown to over 2.3 seconds, decreasing to 2.0

Failed to perform Job "32184673-aa9f-4e17-af0e-bbca77122157" Error: Failed to execute nmap portscan.
    at ScannerScaffolding.worker [as _worker] (/src/src/nmap.js:138:23)
    at process._tickCallback (internal/process/next_tick.js:68:7)
Job Failure submitted succesfully.
```

This error completely crashes the scan, even thought the log indicates that nmap is able to recover from it.

"Unfortunately" this error happens relatively rarely. So debugging / fixing this might be more of a long term effort.