### PR TITLE
Correct npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,11 @@ RUN ./configure && \
 
 FROM node:12-alpine
 
-COPY package.json package-lock.json /src/ 
+COPY package.json package-lock.json /src/
+WORKDIR /src
 RUN npm install --production
 COPY --from=buildcontainer /usr/local/ /usr/local
 COPY . /src
-
-WORKDIR /src
 
 RUN apk update && \
     apk upgrade --no-cache && \


### PR DESCRIPTION
`npm install` was running in the wrong directory, which lead to the dependencies not getting installed correctly.

Previously:

```txt
Step 13/34 : FROM node:12-alpine
 ---> 4c6406de22fd
Step 14/34 : COPY package.json package-lock.json /src/
 ---> 93fd346bd327
Step 15/34 : RUN npm install --production
 ---> Running in 484572248b9f
npm WARN saveError ENOENT: no such file or directory, open '/package.json'
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN enoent ENOENT: no such file or directory, open '/package.json'
npm WARN !invalid#2 No description
npm WARN !invalid#2 No repository field.
npm WARN !invalid#2 No README data
npm WARN !invalid#2 No license field.

up to date in 0.755s
found 0 vulnerabilities
```

On startup:

```txt
> securebox-nmap@1.0.5 start /src
> node index.js

internal/modules/cjs/loader.js:800
    throw err;
    ^

Error: Cannot find module '@securecodebox/scanner-scaffolding'
Require stack:
- /src/index.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:797:15)
    at Function.Module._load (internal/modules/cjs/loader.js:690:27)
    at Module.require (internal/modules/cjs/loader.js:852:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/src/index.js:19:28)
    at Module._compile (internal/modules/cjs/loader.js:959:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:995:10)
    at Module.load (internal/modules/cjs/loader.js:815:32)
    at Function.Module._load (internal/modules/cjs/loader.js:727:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1047:10) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/src/index.js' ]
}
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! securebox-nmap@1.0.5 start: `node index.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the securebox-nmap@1.0.5 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/nmap_user/.npm/_logs/2020-01-09T10_34_23_150Z-debug.log
```